### PR TITLE
Move to folder where script is located

### DIFF
--- a/{{cookiecutter.projectDirectory}}/buildStrings
+++ b/{{cookiecutter.projectDirectory}}/buildStrings
@@ -1,3 +1,5 @@
 #!/bin/bash
+cd $(dirname $0)
+
 texterify download
 swiftgen


### PR DESCRIPTION
`cd $(dirname $0)`
changes the directory to the directory the script is located
With that change the script can be executed by clicking on it in the finder